### PR TITLE
Now using oauth token for bulk actions

### DIFF
--- a/ci-droid-autoconfigure/src/main/java/com/societegenerale/cidroid/config/CiDroidActionsConfiguration.java
+++ b/ci-droid-autoconfigure/src/main/java/com/societegenerale/cidroid/config/CiDroidActionsConfiguration.java
@@ -1,9 +1,7 @@
 package com.societegenerale.cidroid.config;
 
-import com.societegenerale.cidroid.extensions.actionToReplicate.OverwriteStaticFileAction;
-import com.societegenerale.cidroid.extensions.actionToReplicate.ReplaceMavenProfileAction;
-import com.societegenerale.cidroid.extensions.actionToReplicate.SimpleReplaceAction;
-import com.societegenerale.cidroid.extensions.actionToReplicate.TemplateBasedContentAction;
+import com.societegenerale.cidroid.api.actionToReplicate.ActionToReplicate;
+import com.societegenerale.cidroid.extensions.actionToReplicate.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,27 +9,45 @@ import org.springframework.context.annotation.Configuration;
 public class CiDroidActionsConfiguration {
 
     @Bean
-    public OverwriteStaticFileAction overwriteStaticFileAction() {
+    public ActionToReplicate overwriteStaticFileAction() {
 
         return new OverwriteStaticFileAction();
     }
 
     @Bean
-    public ReplaceMavenProfileAction replaceMavenProfileAction() {
+    public ActionToReplicate replaceMavenProfileAction() {
 
         return new ReplaceMavenProfileAction();
     }
 
     @Bean
-    public SimpleReplaceAction simpleReplaceAction() {
+    public ActionToReplicate simpleReplaceAction() {
 
         return new SimpleReplaceAction();
     }
 
     @Bean
-    public TemplateBasedContentAction templateBasedContentAction() {
+    public ActionToReplicate addXmlElementAction() {
+
+        return new AddXmlElementAction();
+    }
+
+    @Bean
+    public ActionToReplicate removeXmlElementAction() {
+
+        return new RemoveXmlElementAction();
+    }
+
+    @Bean
+    public ActionToReplicate templateBasedContentAction() {
 
         return new TemplateBasedContentAction();
+    }
+
+    @Bean
+    public ActionToReplicate removeMavenDependencyOrPluginAction() {
+
+        return new RemoveMavenDependencyOrPluginAction();
     }
 
 }

--- a/ci-droid-core/src/main/java/com/societegenerale/cidroid/CiDroidActionsController.java
+++ b/ci-droid-core/src/main/java/com/societegenerale/cidroid/CiDroidActionsController.java
@@ -54,7 +54,7 @@ public class CiDroidActionsController {
         for (ResourceToUpdate resourceToUpdate : bulkUpdateCommand.getResourcesToUpdate()) {
 
             BulkUpdateCommand singleResourceUpdateCommand = BulkUpdateCommand.builder().gitLogin(bulkUpdateCommand.getGitLogin())
-                    .gitPassword(bulkUpdateCommand.getGitPassword())
+                    .gitHubOauthToken(bulkUpdateCommand.getGitHubOauthToken())
                     .email(bulkUpdateCommand.getEmail())
                     .gitHubInteractionType(bulkUpdateCommand.getGitHubInteractionType())
                     .updateAction(bulkUpdateCommand.getUpdateAction())

--- a/ci-droid-core/src/main/java/com/societegenerale/cidroid/model/BulkUpdateCommand.java
+++ b/ci-droid-core/src/main/java/com/societegenerale/cidroid/model/BulkUpdateCommand.java
@@ -15,14 +15,14 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString(exclude = "gitPassword")
+@ToString(exclude = "gitHubOauthToken")
 public class BulkUpdateCommand {
 
     @NotEmpty
     private String gitLogin;
 
     @NotEmpty
-    private String gitPassword;
+    private String gitHubOauthToken;
 
     @Email
     private String email;

--- a/ci-droid-core/src/test/java/com/societegenerale/cidroid/CiDroidActionsControllerTest.java
+++ b/ci-droid-core/src/test/java/com/societegenerale/cidroid/CiDroidActionsControllerTest.java
@@ -42,7 +42,7 @@ public class CiDroidActionsControllerTest {
 
     private static final String SOME_USER_NAME = "someUserName";
 
-    private static final String SOME_PASSWORD = "somePassword";
+    private static final String SOME_OAUTH_TOKEN = "abcdef123456";
 
     private static final String SOME_EMAIL = "someEmail@someDomain.com";
 
@@ -64,7 +64,7 @@ public class CiDroidActionsControllerTest {
     private ActionToReplicate mockAvailableAction2;
 
     private BulkUpdateCommand.BulkUpdateCommandBuilder baseBatchUpdateCommandBuilder=BulkUpdateCommand.builder().gitLogin(SOME_USER_NAME)
-                                                                                        .gitPassword(SOME_PASSWORD)
+                                                                                        .gitHubOauthToken(SOME_OAUTH_TOKEN)
                                                                                         .email(SOME_EMAIL);
 
     private ObjectMapper objectMapper=new ObjectMapper();
@@ -106,7 +106,7 @@ public class CiDroidActionsControllerTest {
         for(BulkUpdateCommand actualBulkUpdateCommand : actualBulkUpdateCommands){
 
             assertThat(actualBulkUpdateCommand.getGitLogin()).as("login" + getAssertionMessage(actualBulkUpdateCommand)).isEqualTo(SOME_USER_NAME);
-            assertThat(actualBulkUpdateCommand.getGitPassword()).as("password" + getAssertionMessage(actualBulkUpdateCommand)).isEqualTo(SOME_PASSWORD);
+            assertThat(actualBulkUpdateCommand.getGitHubOauthToken()).as("OAuth token" + getAssertionMessage(actualBulkUpdateCommand)).isEqualTo(SOME_OAUTH_TOKEN);
             assertThat(actualBulkUpdateCommand.getEmail()).as("email" + getAssertionMessage(actualBulkUpdateCommand)).isEqualTo(SOME_EMAIL);
             assertThat(actualBulkUpdateCommand.getGitHubInteractionType()).as("gitub interaction type" + getAssertionMessage(actualBulkUpdateCommand)).isEqualTo(new DirectPushGitHubInteraction());
             assertThat(actualBulkUpdateCommand.getUpdateAction()).as("updateAction" + getAssertionMessage(actualBulkUpdateCommand)).isEqualTo(replaceAction);
@@ -156,7 +156,7 @@ public class CiDroidActionsControllerTest {
     public void shouldReturnBadRequestIfGitLoginIsNotProvided() throws Exception {
 
         BulkUpdateCommand invalidBulkUpdateCommand_noLogin =BulkUpdateCommand.builder()
-                .gitPassword(SOME_PASSWORD)
+                .gitHubOauthToken(SOME_OAUTH_TOKEN)
                 .email(SOME_EMAIL)
                 .build();
 
@@ -180,7 +180,7 @@ public class CiDroidActionsControllerTest {
 
         BulkUpdateCommand invalidBulkUpdateCommand_incorrectEmailFormat =BulkUpdateCommand.builder()
                 .gitLogin(SOME_USER_NAME)
-                .gitPassword(SOME_PASSWORD)
+                .gitHubOauthToken(SOME_OAUTH_TOKEN)
                 .email("some.incorrectEmail.com")
                 .build();
 

--- a/ci-droid-core/src/test/resources/bulkUpdate_directPush_Command.json
+++ b/ci-droid-core/src/test/resources/bulkUpdate_directPush_Command.json
@@ -1,6 +1,6 @@
 {
   "gitLogin": "someUserName",
-  "gitPassword": "somePassword",
+  "gitHubOauthToken": "somePassword",
   "email": "someEmail@someDomain.com",
   "commitMessage" : "some commit message",
   "updateAction": {

--- a/ci-droid-core/src/test/resources/bulkUpdate_pullRequest_Command.json
+++ b/ci-droid-core/src/test/resources/bulkUpdate_pullRequest_Command.json
@@ -1,6 +1,6 @@
 {
   "gitLogin": "someUserName",
-  "gitPassword": "somePassword",
+  "gitHubOauthToken": "somePassword",
   "email": "someEmail@someDomain.com",
   "commitMessage" : "some commit message",
   "updateAction": {

--- a/ci-droid-core/src/test/resources/bulkUpdate_pullRequest_noBranch_Command.json
+++ b/ci-droid-core/src/test/resources/bulkUpdate_pullRequest_noBranch_Command.json
@@ -1,6 +1,6 @@
 {
   "gitLogin": "someUserName",
-  "gitPassword": "somePassword",
+  "gitHubOauthToken": "somePassword",
   "email": "someEmail@someDomain.com",
   "commitMessage" : "some commit message",
   "updateAction": {

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <jacoco.version>0.8.1</jacoco.version>
 
         <ci-droid-api.version>1.0.2</ci-droid-api.version>
-        <ci-droid-extensions.version>1.0.2</ci-droid-extensions.version>
+        <ci-droid-extensions.version>1.0.4</ci-droid-extensions.version>
 
     </properties>
 


### PR DESCRIPTION
## Summary

since task consumer will now expect an Oauth token to be provided for bulk actions (see https://github.com/societe-generale/ci-droid-tasks-consumer/issues/8), we need to adapt here accordingly 
