### PR TITLE
Fix for building the project in openJDK 11

### DIFF
--- a/ci-droid-core/pom.xml
+++ b/ci-droid-core/pom.xml
@@ -23,7 +23,6 @@
         <java.version>1.8</java.version>
 
         <assertj.version>3.9.1</assertj.version>
-        <lombok.version>1.16.22</lombok.version>
 
         <jacoco.version>0.8.1</jacoco.version>
 

--- a/ci-droid-core/pom.xml
+++ b/ci-droid-core/pom.xml
@@ -23,7 +23,7 @@
         <java.version>1.8</java.version>
 
         <assertj.version>3.9.1</assertj.version>
-        <lombok.version>1.16.20</lombok.version>
+        <lombok.version>1.16.22</lombok.version>
 
         <jacoco.version>0.8.1</jacoco.version>
 
@@ -79,6 +79,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <spring-cloud-stream.version>Ditmars.SR3</spring-cloud-stream.version>
         <spring-cloud.version>Edgware.SR2</spring-cloud.version>
         <assertj.version>3.9.1</assertj.version>
-        <lombok.version>1.16.20</lombok.version>
+        <lombok.version>1.16.22</lombok.version>
 
         <!-- need to declare it, otherwise Spring Boot 1.5 parent pom overrides the version, and it becomes not compatible with hibernate-validator anymore -->
         <javax-validation.version>2.0.1.Final</javax-validation.version>
@@ -60,7 +60,7 @@
 
         <ci-droid-api.version>1.0.5</ci-droid-api.version>
         <ci-droid-extensions.version>1.0.6</ci-droid-extensions.version>
-
+        <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
     </properties>
 
     <issueManagement>
@@ -145,7 +145,11 @@
 
     <build>
         <plugins>
-
+            <!-- JDK 11 issue : https://github.com/spring-guides/gs-maven/issues/23 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <spring-cloud-stream.version>Ditmars.SR3</spring-cloud-stream.version>
         <spring-cloud.version>Edgware.SR2</spring-cloud.version>
         <assertj.version>3.9.1</assertj.version>
-        <lombok.version>1.16.22</lombok.version>
+        <lombok.version>1.18.4</lombok.version>
 
         <!-- need to declare it, otherwise Spring Boot 1.5 parent pom overrides the version, and it becomes not compatible with hibernate-validator anymore -->
         <javax-validation.version>2.0.1.Final</javax-validation.version>


### PR DESCRIPTION
## Summary

Unable to build the project with openJDK 11

## Details

There were issues while building the project with openJDK 11

**Issue 1:** https://github.com/rzwitserloot/lombok/issues/1651

**Issue 2:** https://github.com/spring-guides/gs-maven/issues/23

## Context

This change is required to be able to build in openJDK 11. 

This should have no impacts.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->