### PR TITLE
 fix(gui): fixed the font consistency issue

### DIFF
--- a/ci-droid-gui/src/sass/styles.scss
+++ b/ci-droid-gui/src/sass/styles.scss
@@ -9,7 +9,9 @@
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
 $custom-typography: mat-typography-config(
-  $font-family: 'Montserrat' sans-serif
+  $font-family: 'Montserrat',
+  'Roboto',
+  sans-serif
 );
 @include mat-core($custom-typography);
 
@@ -70,5 +72,5 @@ html,
 body {
   width: 100vw;
   height: 100vh;
-  font-family: 'Montserrat', sans-serif;
+  font-family: 'Montserrat', 'Roboto', sans-serif;
 }

--- a/ci-droid-gui/src/sass/styles.scss
+++ b/ci-droid-gui/src/sass/styles.scss
@@ -8,10 +8,9 @@
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
+$global-font-family: 'Montserrat', 'Roboto', sans-serif;
 $custom-typography: mat-typography-config(
-  $font-family: 'Montserrat',
-  'Roboto',
-  sans-serif
+  $font-family: $global-font-family
 );
 @include mat-core($custom-typography);
 
@@ -72,5 +71,5 @@ html,
 body {
   width: 100vw;
   height: 100vh;
-  font-family: 'Montserrat', 'Roboto', sans-serif;
+  font-family: $global-font-family;
 }


### PR DESCRIPTION
# Description

The fonts used are not consistent i.e. some of them are rendered in Montserrat and Roboto and some in system fonts. It looks really ugly and not consistent.

Full description about this bug can be found out https://github.com/societe-generale/ci-droid/issues/39

Fixes # https://github.com/societe-generale/ci-droid/issues/39


## Type of change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Documentation has been updated accordingly to this PR

## Related issue :

https://github.com/societe-generale/ci-droid/issues/39
