### PR TITLE
Migrate tests towards JUnit 5

### DIFF
--- a/ci-droid-autoconfigure/src/test/java/com/societegenerale/cidroid/CIdroidApplicationTest.java
+++ b/ci-droid-autoconfigure/src/test/java/com/societegenerale/cidroid/CIdroidApplicationTest.java
@@ -1,24 +1,23 @@
 package com.societegenerale.cidroid;
 
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@RunWith(SpringRunner.class)
-public class CIdroidApplicationTest {
+@ExtendWith(SpringExtension.class)
+class CIdroidApplicationTest {
 
     @Autowired
     private ApplicationContext appContext;
 
     @Test
-    public void appContextShouldLoad() {
+    void appContextShouldLoad() {
         assertThat(appContext).isNotNull();
     }
 

--- a/ci-droid-core/src/test/java/com/societegenerale/cidroid/CiDroidPropertiesTest.java
+++ b/ci-droid-core/src/test/java/com/societegenerale/cidroid/CiDroidPropertiesTest.java
@@ -1,47 +1,42 @@
 package com.societegenerale.cidroid;
 
-import org.junit.Test;
-
-import java.util.Arrays;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class CiDroidPropertiesTest {
+class CiDroidPropertiesTest {
 
     @Test
-    public void cantHaveBothIncludedAndExcludedRepos(){
+    void cantHaveBothIncludedAndExcludedRepos() {
 
-        CiDroidProperties ciDroidProperties=new CiDroidProperties(Arrays.asList("repoToExclude"),Arrays.asList("repoToInclude"));
+        CiDroidProperties ciDroidProperties = new CiDroidProperties(singletonList("repoToExclude"), singletonList("repoToInclude"));
 
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(
-                () -> {ciDroidProperties.validate();}
-        ).withMessage("You can't define both included AND excluded repositories - please configure only one type");
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(ciDroidProperties::validate)
+                .withMessage("You can't define both included AND excluded repositories - please configure only one type");
+    }
+
+    @Test
+    void canHaveIncludedReposOnly() {
+
+        CiDroidProperties ciDroidProperties = new CiDroidProperties(emptyList(), singletonList("repoToInclude"));
+
+        assertThatCode(ciDroidProperties::validate)
+                .doesNotThrowAnyException();
 
     }
 
     @Test
-    public void canHaveIncludedReposOnly(){
+    void canHaveExcludedReposOnly() {
 
-        CiDroidProperties ciDroidProperties=new CiDroidProperties(emptyList(),Arrays.asList("repoToInclude"));
+        CiDroidProperties ciDroidProperties = new CiDroidProperties(singletonList("repoToExclude"), emptyList());
 
-        assertThatCode(
-                () -> {ciDroidProperties.validate();}
-        ).doesNotThrowAnyException();
-
-    }
-
-    @Test
-    public void canHaveExcludedReposOnly(){
-
-        CiDroidProperties ciDroidProperties=new CiDroidProperties(Arrays.asList("repoToExclude"),emptyList());
-
-        assertThatCode(
-                () -> {ciDroidProperties.validate();}
-        ).doesNotThrowAnyException();
+        assertThatCode(ciDroidProperties::validate)
+                .doesNotThrowAnyException();
 
     }
-
 
 }

--- a/ci-droid-core/src/test/java/com/societegenerale/cidroid/PushEventTest.java
+++ b/ci-droid-core/src/test/java/com/societegenerale/cidroid/PushEventTest.java
@@ -2,28 +2,27 @@ package com.societegenerale.cidroid;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.model.github.PushEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PushEventTest {
+class PushEventTest {
 
-    ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void fieldsAreDeserialized() throws IOException {
+    void fieldsAreDeserialized() throws IOException {
 
-        String pushEventAsString= TestUtils.readFromInputStream(getClass().getResourceAsStream("/pushEvent.json"));
+        String pushEventAsString = TestUtils.readFromInputStream(getClass().getResourceAsStream("/pushEvent.json"));
 
-        PushEvent pushEvent=objectMapper.readValue(pushEventAsString,PushEvent.class);
+        PushEvent pushEvent = objectMapper.readValue(pushEventAsString, PushEvent.class);
 
         assertThat(pushEvent).isNotNull();
 
         assertThat(pushEvent.getRepository()).isNotNull();
 
     }
-
 
 }

--- a/ci-droid-core/src/test/java/com/societegenerale/cidroid/controllers/WebHookControllerTest.java
+++ b/ci-droid-core/src/test/java/com/societegenerale/cidroid/controllers/WebHookControllerTest.java
@@ -3,10 +3,9 @@ package com.societegenerale.cidroid.controllers;
 import com.societegenerale.cidroid.AdditionalTestConfig;
 import com.societegenerale.cidroid.CiDroidProperties;
 import com.societegenerale.cidroid.TestUtils;
-import com.societegenerale.cidroid.controllers.WebHookController;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.IOException;
@@ -26,30 +25,30 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(WebHookController.class)
 @Import(AdditionalTestConfig.class)
-public class WebHookControllerTest {
+class WebHookControllerTest {
 
     @Autowired
     private MockMvc mvc;
 
     @MockBean(name = "push-on-default-branch")
-    MessageChannel pushOnDefaultBranchOutputChannel;
+    private MessageChannel pushOnDefaultBranchOutputChannel;
 
     @MockBean(name = "pull-request-event")
-    MessageChannel pullRequestEventChannel;
+    private MessageChannel pullRequestEventChannel;
 
     @Autowired
-    CiDroidProperties ciDroidProperties;
+    private CiDroidProperties ciDroidProperties;
 
     @Captor
-    ArgumentCaptor<Message> sentMessage;
+    private ArgumentCaptor<Message> sentMessage;
 
-    String pushEventAsString;
+    private String pushEventAsString;
 
-    @Before
-    public void loadEventAndConfigureMock() throws IOException {
+    @BeforeEach
+    void loadEventAndConfigureMock() throws IOException {
         pushEventAsString = TestUtils.readFromInputStream(getClass().getResourceAsStream("/pushEvent.json"));
 
         ciDroidProperties.getExcluded().clear();
@@ -57,7 +56,7 @@ public class WebHookControllerTest {
     }
 
     @Test
-    public void forwardEventToDefaultBranchOutputChannel_whenPushOnDefaultBranch() throws Exception {
+    void forwardEventToDefaultBranchOutputChannel_whenPushOnDefaultBranch() throws Exception {
 
         performPOSTandExpectSuccess(pushEventAsString);
 
@@ -69,7 +68,7 @@ public class WebHookControllerTest {
     }
 
     @Test
-    public void dontForwardAnything_ifPushEventNotOnDefaultBranch() throws Exception {
+    void dontForwardAnything_ifPushEventNotOnDefaultBranch() throws Exception {
 
         String pushEventOnBranchAsString = pushEventAsString.replaceAll("refs/heads/master", "refs/heads/someOtherBranch");
 
@@ -80,7 +79,7 @@ public class WebHookControllerTest {
     }
 
     @Test
-    public void dontForwardAnything_ifRepoIsExcluded() throws Exception {
+    void dontForwardAnything_ifRepoIsExcluded() throws Exception {
 
         ciDroidProperties.getExcluded().add("public-repo");
 
@@ -95,7 +94,7 @@ public class WebHookControllerTest {
     }
 
     @Test
-    public void dontForwardAnythingIfRepoNotIncluded() throws Exception {
+    void dontForwardAnythingIfRepoNotIncluded() throws Exception {
 
         ciDroidProperties.getIncluded().add("someIncludedRepo");
 
@@ -107,7 +106,7 @@ public class WebHookControllerTest {
     }
 
     @Test
-    public void forwardEventTo_pullRequestEventChannel_whenPullRequestEvent() throws Exception {
+    void forwardEventTo_pullRequestEventChannel_whenPullRequestEvent() throws Exception {
 
         String pullRequestEventAsString = TestUtils.readFromInputStream(getClass().getResourceAsStream("/pullRequestEvent.json"));
 

--- a/ci-droid-core/src/test/java/com/societegenerale/cidroid/model/BulkUpdateCommandTest.java
+++ b/ci-droid-core/src/test/java/com/societegenerale/cidroid/model/BulkUpdateCommandTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.TestUtils;
 import com.societegenerale.cidroid.api.gitHubInteractions.DirectPushGitHubInteraction;
 import com.societegenerale.cidroid.api.gitHubInteractions.PullRequestGitHubInteraction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -15,44 +15,44 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BulkUpdateCommandTest {
+class BulkUpdateCommandTest {
 
-    ObjectMapper objectMapper=new ObjectMapper();
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void canDeserializeDirectPush() throws IOException {
+    void canDeserializeDirectPush() throws IOException {
 
         String directPushBulkUpdateCommandAsString = TestUtils.readFromInputStream(getClass().getResourceAsStream("/bulkUpdate_directPush_Command.json"));
 
-        BulkUpdateCommand command=objectMapper.readValue(directPushBulkUpdateCommandAsString,BulkUpdateCommand.class);
+        BulkUpdateCommand command = objectMapper.readValue(directPushBulkUpdateCommandAsString, BulkUpdateCommand.class);
 
         assertThat(command.getGitHubInteractionType()).isInstanceOf(DirectPushGitHubInteraction.class);
     }
 
     @Test
-    public void canDeserializePullRequest() throws IOException {
+    void canDeserializePullRequest() throws IOException {
 
         String directPushBulkUpdateCommandAsString = TestUtils.readFromInputStream(getClass().getResourceAsStream("/bulkUpdate_pullRequest_Command.json"));
 
-        BulkUpdateCommand command=objectMapper.readValue(directPushBulkUpdateCommandAsString,BulkUpdateCommand.class);
+        BulkUpdateCommand command = objectMapper.readValue(directPushBulkUpdateCommandAsString, BulkUpdateCommand.class);
 
         assertThat(command.getGitHubInteractionType()).isInstanceOf(PullRequestGitHubInteraction.class);
-        assertThat(((PullRequestGitHubInteraction)command.getGitHubInteractionType()).getBranchNameToCreate()).isEqualTo("branchForPr");
+        assertThat(((PullRequestGitHubInteraction) command.getGitHubInteractionType()).getBranchNameToCreate()).isEqualTo("branchForPr");
     }
 
     @Test
-    public void canDeserializePullRequestWithNoBranch_butInvalid() throws IOException {
+    void canDeserializePullRequestWithNoBranch_butInvalid() throws IOException {
 
         String directPushBulkUpdateCommandAsString = TestUtils.readFromInputStream(getClass().getResourceAsStream("/bulkUpdate_pullRequest_noBranch_Command.json"));
 
-        BulkUpdateCommand command=objectMapper.readValue(directPushBulkUpdateCommandAsString,BulkUpdateCommand.class);
+        BulkUpdateCommand command = objectMapper.readValue(directPushBulkUpdateCommandAsString, BulkUpdateCommand.class);
 
         assertThat(command.getGitHubInteractionType()).isInstanceOf(PullRequestGitHubInteraction.class);
 
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         Validator validator = factory.getValidator();
 
-        PullRequestGitHubInteraction interaction=(PullRequestGitHubInteraction)command.getGitHubInteractionType();
+        PullRequestGitHubInteraction interaction = (PullRequestGitHubInteraction) command.getGitHubInteractionType();
 
         Set<ConstraintViolation<PullRequestGitHubInteraction>> violations = validator.validate(interaction);
         assertThat(violations).hasSize(1);

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,24 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>android-json</artifactId>
                     <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

Migration of the JUnit tests from version 4 to 5.

## Details

- Replace annotations (Test, Before, After...)
- Remove useless public scopes
- Replace SpringRunner by SpringExtension